### PR TITLE
Add IXR-X1, IXR-X3, IXR-Xs

### DIFF
--- a/sros/docker/launch.py
+++ b/sros/docker/launch.py
@@ -151,17 +151,65 @@ SROS_VARIANTS = {
             }
         ],
     },
+    ## IXR-X1
+    ## cpu=2 ram=4 slot=A chassis=ixr-x card=cpm-ixr-x/imm32-qsfp28+4-qsfpdd
     "ixr-x1": {
         "deployment_model": "distributed",
-        "min_ram": 4,  # minimum RAM requirements
+        # control plane (CPM)
         "max_nics": 36,
-        **line_card_config(
-            chassis="ixr-x",
-            card="cpm-ixr-x",
-            card_type="imm32-qsfp28+4-qsfpdd",
-            mda="m32-qsfp28+4-qsfpdd",
-            integrated=False,
-        ),
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=ixr-x card=cpm-ixr-x",
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 4,
+                "timos_line": "chassis=ixr-x slot=1 card=imm32-qsfp28+4-qsfpdd",
+                "card_config": """
+            """,
+            }
+        ],
+    },
+    ## IXR-X3
+    ## cpu=2 ram=4 slot=A chassis=ixr-x card=cpm-ixr-x/imm36-qsfpdd
+    "ixr-x3": {
+        "deployment_model": "distributed",
+        # control plane (CPM)
+        "max_nics": 36,
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=ixr-x card=cpm-ixr-x",
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 4,
+                "timos_line": "chassis=ixr-x slot=1 card=imm36-qsfpdd",
+                "card_config": """
+            """,
+            }
+        ],
+    },
+    ## IXR-Xs
+    ## cpu=2 ram=4 slot=A chassis=ixr-x card=cpm-ixr-x/imm6-qsfpdd+48-sfp56
+    "ixr-xs": {
+        "deployment_model": "distributed",
+        # control plane (CPM)
+        "max_nics": 54,
+        "cp": {
+            "min_ram": 4,
+            "timos_line": "slot=A chassis=ixr-x card=cpm-ixr-x",
+        },
+        # line card (IOM/XCM)
+        "lcs": [
+            {
+                "min_ram": 4,
+                "timos_line": "chassis=ixr-x slot=1 card=imm6-qsfpdd+48-sfp56",
+                "card_config": """
+            """,
+            }
+        ],
     },
     "ixr-e-small": {
         "deployment_model": "distributed",


### PR DESCRIPTION
Update PR to include IXR-X1, IXR-X3, IXR-Xs

Tested with:
```yaml
topology:
  nodes:
    x1:
      mgmt-ipv4: 192.168.8.101
      kind: vr-sros
      type: 'ixr-x1'
      image: vrnetlab/vr-sros:23.10.R1
      runtime: docker
      binds:
      - /home/proxsys/vrnetlab/sros/docker/launch.py:/launch.py
      license: ../../sros/license-sros23.3.R3-202310.txt
    x3:
      mgmt-ipv4: 192.168.8.102
      kind: vr-sros
      type: 'ixr-x3'
      image: vrnetlab/vr-sros:23.10.R1
      runtime: docker
      binds:
      - /home/proxsys/vrnetlab/sros/docker/launch.py:/launch.py
      license: ../../sros/license-sros23.3.R3-202310.txt
    xs:
      mgmt-ipv4: 192.168.8.103
      kind: vr-sros
      type: 'ixr-xs'
      image: vrnetlab/vr-sros:23.10.R1
      runtime: docker
      binds:
      - /home/proxsys/vrnetlab/sros/docker/launch.py:/launch.py
      license: ../../sros/license-sros23.3.R3-202310.txt

```

Output:
```
A:admin@x1# show chassis
===============================================================================
System Information
===============================================================================
  Name                              : x1
  Type                              : 7250 IXR-x
  Chassis Topology                  : Standalone
  Location                          : (Not Specified)
  Coordinates                       : (Not Specified)
  CLLI code                         :           
  Number of slots                   : 2
  Oper number of slots              : 2
  Num of faceplate ports/connectors : 54
  Num of physical ports             : 0
  Critical LED state                : Off
  Major LED state                   : Red
  Minor LED state                   : Amber
  Over Temperature state            : OK
  Base MAC address                  : 0c:00:61:cb:03:00

===============================================================================
Chassis Summary
===============================================================================
Chassis   Role                Status
-------------------------------------------------------------------------------
1         Standalone          up
===============================================================================

[/]
A:admin@x1# 
```
```
A:admin@x3# show chassis
===============================================================================
System Information
===============================================================================
  Name                              : x3
  Type                              : 7250 IXR-x
  Chassis Topology                  : Standalone
  Location                          : (Not Specified)
  Coordinates                       : (Not Specified)
  CLLI code                         :           
  Number of slots                   : 2
  Oper number of slots              : 2
  Num of faceplate ports/connectors : 54
  Num of physical ports             : 0
  Critical LED state                : Off
  Major LED state                   : Off
  Minor LED state                   : Off
  Over Temperature state            : OK
  Base MAC address                  : 0c:00:8a:34:56:00

===============================================================================
Chassis Summary
===============================================================================
Chassis   Role                Status
-------------------------------------------------------------------------------
1         Standalone          up
===============================================================================

[/]
```
```
A:admin@xs#                 show chassis
===============================================================================
System Information
===============================================================================
  Name                              : xs
  Type                              : 7250 IXR-x
  Chassis Topology                  : Standalone
  Location                          : (Not Specified)
  Coordinates                       : (Not Specified)
  CLLI code                         :           
  Number of slots                   : 2
  Oper number of slots              : 2
  Num of faceplate ports/connectors : 54
  Num of physical ports             : 0
  Critical LED state                : Off
  Major LED state                   : Off
  Minor LED state                   : Off
  Over Temperature state            : OK
  Base MAC address                  : 0c:00:ca:46:ff:00

===============================================================================
Chassis Summary
===============================================================================
Chassis   Role                Status
-------------------------------------------------------------------------------
1         Standalone          up
===============================================================================

[/show system]
A:admin@xs# 
```